### PR TITLE
Add board functions previously supported by python-tilewe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,5 +40,5 @@ set(SOURCES
 
 add_library(tilewe STATIC ${SOURCES})
 
-add_executable(testboard Source/Test/TestBoard.c)
-target_link_libraries(testboard tilewe -static)
+add_executable(test Source/Test/Test.c)
+target_link_libraries(test tilewe -static)

--- a/Source/Test/Test.c
+++ b/Source/Test/Test.c
@@ -169,6 +169,96 @@ TEST_CASE(PlayerCorners,
     }
 })
 
+TEST_CASE(IsLegal, 
+{
+    Tw_Board board; 
+    Tw_InitBoard(&board, 4); 
+
+    TEST_EXPECT_EQ(
+        Tw_Board_IsLegal(&board, Tw_NoMove), 
+        false
+    );
+
+    TEST_EXPECT_EQ(
+        Tw_Board_IsLegal(&board, Tw_MakeMove(
+            Tw_Pc_F5, 
+            Tw_Rot_N, 
+            Tw_Tile_A02, 
+            Tw_Tile_A01
+        )), 
+        false
+    ); 
+
+    TEST_EXPECT_EQ(
+        Tw_Board_IsLegal(&board, Tw_MakeMove(
+            Tw_Pc_F5, 
+            Tw_Rot_N, 
+            Tw_Tile_A02, 
+            Tw_Tile_A02
+        )), 
+        false
+    ); 
+
+    TEST_EXPECT_EQ(
+        Tw_Board_IsLegal(&board, Tw_MakeMove(
+            Tw_Pc_F5, 
+            Tw_Rot_S, 
+            Tw_Tile_B01, 
+            Tw_Tile_A01
+        )), 
+        false
+    ); 
+
+    TEST_EXPECT_EQ(
+        Tw_Board_IsLegal(&board, Tw_MakeMove(
+            Tw_Pc_F5, 
+            Tw_Rot_S, 
+            Tw_Tile_A01, 
+            Tw_Tile_A01
+        )), 
+        true
+    ); 
+})
+
+TEST_CASE(MakeMove, 
+{
+    // contact not in piece 
+    TEST_EXPECT_EQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5, Tw_Rot_N, Tw_Tile_A01, Tw_Tile_A01), 
+        Tw_NoMove
+    );
+
+    // contact not valid 
+    TEST_EXPECT_EQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5, Tw_Rot_N, Tw_Tile_B02, Tw_Tile_A01), 
+        Tw_NoMove
+    );
+
+    // invalid piece
+    TEST_EXPECT_EQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5 + 100, Tw_Rot_N, Tw_Tile_B01, Tw_Tile_B01), 
+        Tw_NoMove
+    );
+
+    // invalid rotation
+    TEST_EXPECT_EQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5, Tw_Rot_N + 100, Tw_Tile_B01, Tw_Tile_B01), 
+        Tw_NoMove
+    );
+
+    // invalid target tile 
+    TEST_EXPECT_EQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5, Tw_Rot_N, Tw_Tile_B01, Tw_Tile_B01 + 1000), 
+        Tw_NoMove
+    );
+
+    // valid
+    TEST_EXPECT_NEQ(
+        Tw_MakeMove_Safe(Tw_Pc_F5, Tw_Rot_N, Tw_Tile_B01, Tw_Tile_B01), 
+        Tw_NoMove
+    );
+})
+
 TEST_MAIN(TestBoard, 
 {
     Tw_Init(); 
@@ -179,4 +269,6 @@ TEST_MAIN(TestBoard,
     TEST_RUN(NoMovesIffBoardIsFinished); 
     TEST_RUN(PlayerPcs); 
     TEST_RUN(PlayerCorners); 
+    TEST_RUN(IsLegal); 
+    TEST_RUN(MakeMove); 
 })

--- a/Source/Test/TestBoard.c
+++ b/Source/Test/TestBoard.c
@@ -1,91 +1,172 @@
+#include <stdlib.h> 
+
 #include "Test/Test.h" 
 #include "Tilewe/Tilewe.h"
 
 TEST_CASE(FinishedWithin84Ply, 
 {
-    Tw_Board board[1]; 
-    Tw_MoveList moves[1]; 
+    Tw_Board board; 
+    Tw_MoveList moves; 
 
-    Tw_InitBoard(board, 4); 
-    while (!board->Finished)
+    Tw_InitBoard(&board, 4); 
+    while (!board.Finished)
     {
-        Tw_InitMoveList(moves); 
-        Tw_Board_GenMoves(board, moves); 
+        Tw_InitMoveList(&moves); 
+        Tw_Board_GenMoves(&board, &moves); 
 
         // if board is not finished, there are moves to play
-        TEST_EXPECT_GT(moves->Count, 0); 
+        TEST_EXPECT_GT(moves.Count, 0); 
 
-        Tw_Board_Push(board, moves->Elements[0]); 
-        TEST_EXPECT_LTE(board->Ply, 84); 
+        Tw_Board_Push(&board, moves.Elements[0]); 
+        TEST_EXPECT_LTE(board.Ply, 84); 
     }
 
     // all four players can play at least this many turns, and probably more
-    TEST_EXPECT_GT(board->Ply, 3 * 4); 
+    TEST_EXPECT_GT(board.Ply, 3 * 4); 
 })
 
 TEST_CASE(NumPlayerPcs, 
 {
-    Tw_Board board[1]; 
+    Tw_Board board; 
 
-    Tw_InitBoard(board, 3); 
+    Tw_InitBoard(&board, 3); 
 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Blue), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Yellow), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Red), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Green), 0); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Blue), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Yellow), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Red), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Green), 0); 
 
-    Tw_Board_Push(board, Tw_MakeMove(Tw_Pc_Z5, Tw_Rot_E, Tw_Tile_A01, Tw_Tile_A01)); 
+    Tw_Board_Push(&board, Tw_MakeMove(Tw_Pc_Z5, Tw_Rot_E, Tw_Tile_A01, Tw_Tile_A01)); 
 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Blue), 20); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Yellow), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Red), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Green), 0); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Blue), 20); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Yellow), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Red), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Green), 0); 
 
-    Tw_Board_Push(board, Tw_MakeMove(Tw_Pc_Z5, Tw_Rot_N, Tw_Tile_A20, Tw_Tile_A03)); 
+    Tw_Board_Push(&board, Tw_MakeMove(Tw_Pc_Z5, Tw_Rot_N, Tw_Tile_A20, Tw_Tile_A03)); 
 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Blue), 20); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Yellow), 20); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Red), 21); 
-    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, Tw_Color_Green), 0); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Blue), 20); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Yellow), 20); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Red), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Green), 0); 
 })
 
 TEST_CASE(PushPopIsSameState, 
 {
-    Tw_Board board[1]; 
-    Tw_MoveList moves[1]; 
+    Tw_Board board; 
+    Tw_MoveList moves; 
 
-    Tw_InitBoard(board, 4); 
-    Tw_InitMoveList(moves); 
-    Tw_Board_GenMoves(board, moves); 
+    Tw_InitBoard(&board, 4); 
+    Tw_InitMoveList(&moves); 
+    Tw_Board_GenMoves(&board, &moves); 
 
-    for (int i = 0; i < moves->Count; i++) 
+    for (int i = 0; i < moves.Count; i++) 
     {
         int numPcs[Tw_NumColors]; 
         for (Tw_Color col = Tw_Color_First; col < Tw_NumColors; col++) 
         {
-            numPcs[col] = Tw_Board_NumPlayerPcs(board, col); 
+            numPcs[col] = Tw_Board_NumPlayerPcs(&board, col); 
         }
 
-        Tw_Board_Push(board, moves->Elements[i]); 
-        Tw_Board_Pop(board); 
+        Tw_Board_Push(&board, moves.Elements[i]); 
+        Tw_Board_Pop(&board); 
 
         for (Tw_Color col = Tw_Color_First; col < Tw_NumColors; col++) 
         {
-            TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(board, col), numPcs[col]); 
+            TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, col), numPcs[col]); 
         }
     }
 })
 
 TEST_CASE(InitialMoveCount, 
 {
-    Tw_Board board[1]; 
-    Tw_MoveList moves[1]; 
+    Tw_Board board; 
+    Tw_MoveList moves; 
 
-    Tw_InitBoard(board, 4); 
-    Tw_InitMoveList(moves); 
-    Tw_Board_GenMoves(board, moves); 
+    Tw_InitBoard(&board, 4); 
+    Tw_InitMoveList(&moves); 
+    Tw_Board_GenMoves(&board, &moves); 
 
-    TEST_EXPECT_EQ(moves->Count, 232); 
+    TEST_EXPECT_EQ(moves.Count, 232); 
+})
+
+TEST_CASE(NoMovesIffBoardIsFinished, 
+{
+    srand(238089418); 
+
+    Tw_Board board; 
+    Tw_MoveList moves; 
+
+    Tw_InitBoard(&board, 4); 
+    while (!board.Finished) 
+    {
+        Tw_InitMoveList(&moves); 
+        Tw_Board_GenMoves(&board, &moves); 
+
+        TEST_EXPECT_GT(moves.Count, 0); 
+
+        Tw_Board_Push(&board, moves.Elements[rand() % moves.Count]); 
+    }
+
+    Tw_InitMoveList(&moves); 
+    Tw_Board_GenMoves(&board, &moves); 
+
+    TEST_EXPECT_EQ(moves.Count, 0); 
+})
+
+TEST_CASE(PlayerPcs, 
+{
+    Tw_Board board; 
+    Tw_InitBoard(&board, 4); 
+
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Blue), 21); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Yellow), 21); 
+
+    Tw_Board_Push(&board, Tw_MakeMove(Tw_Pc_F5, Tw_Rot_EF, Tw_Tile_A01, Tw_Tile_A01)); 
+
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Blue), 20); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerPcs(&board, Tw_Color_Yellow), 21); 
+
+    Tw_PcList pcs; 
+    Tw_InitPcList(&pcs); 
+    Tw_Board_PlayerPcs(&board, Tw_Color_Blue, &pcs); 
+
+    TEST_EXPECT_EQ(pcs.Count, 20); 
+
+    for (int i = 0; i < pcs.Count; i++) 
+    {
+        TEST_EXPECT_NEQ(pcs.Elements[i], Tw_Pc_F5); 
+    }
+})
+
+TEST_CASE(PlayerCorners, 
+{
+    Tw_Board board; 
+    Tw_InitBoard(&board, 4); 
+
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerCorners(&board, Tw_Color_Blue), 4); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerCorners(&board, Tw_Color_Yellow), 4); 
+
+    Tw_Board_Push(&board, Tw_MakeMove(Tw_Pc_L5, Tw_Rot_SF, Tw_Tile_A01, Tw_Tile_A01)); 
+
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerCorners(&board, Tw_Color_Blue), 2); 
+    TEST_EXPECT_EQ(Tw_Board_NumPlayerCorners(&board, Tw_Color_Yellow), 3); 
+
+    Tw_TileList tiles; 
+    Tw_InitTileList(&tiles); 
+    Tw_Board_PlayerCorners(&board, Tw_Color_Blue, &tiles); 
+
+    TEST_EXPECT_EQ(tiles.Count, 2); 
+
+    if (tiles.Elements[0] == Tw_Tile_C03) 
+    {
+        TEST_EXPECT_EQ(tiles.Elements[1], Tw_Tile_C05); 
+    }
+    else 
+    {
+        TEST_EXPECT_EQ(tiles.Elements[0], Tw_Tile_C05); 
+        TEST_EXPECT_EQ(tiles.Elements[1], Tw_Tile_C03); 
+    }
 })
 
 TEST_MAIN(TestBoard, 
@@ -95,4 +176,7 @@ TEST_MAIN(TestBoard,
     TEST_RUN(NumPlayerPcs); 
     TEST_RUN(PushPopIsSameState); 
     TEST_RUN(InitialMoveCount); 
+    TEST_RUN(NoMovesIffBoardIsFinished); 
+    TEST_RUN(PlayerPcs); 
+    TEST_RUN(PlayerCorners); 
 })

--- a/Source/Tilewe/Board.h
+++ b/Source/Tilewe/Board.h
@@ -668,3 +668,46 @@ static inline int Tw_Board_NumPlayerPcs(const Tw_Board* board, Tw_Color col)
 
     return total; 
 }
+
+/**
+ * Appends list of remaining pieces for the player. 
+ * 
+ * @param board Board
+ * @param col Player
+ * @param out Output list 
+ */
+static inline void Tw_Board_PlayerPcs(const Tw_Board* board, Tw_Color col, Tw_PcList* out) 
+{
+    for (Tw_Pc pc = Tw_Pc_First; pc < Tw_NumPcs; pc++) 
+    {
+        if (Tw_RotPcConSet_HasAny(&board->Players[col].RotPcCons, &Tw_PcInfos[pc].RotPcCons)) 
+        {
+            Tw_PcList_Push(out, pc); 
+        }
+    }
+}
+
+/**
+ * @param board Board
+ * @param col Player
+ * @return Number of playable open corners for a player. 
+ */
+static inline int Tw_Board_NumPlayerCorners(const Tw_Board* board, Tw_Color col) 
+{
+    return Tw_TileSet_Count(&board->Players[col].OpenCorners.Keys); 
+}
+
+/**
+ * Appends all playable open corners for a player to a list. 
+ * 
+ * @param board Board
+ * @param col Player
+ * @param out Output list 
+ */
+static inline void Tw_Board_PlayerCorners(const Tw_Board* board, Tw_Color col, Tw_TileList* out) 
+{
+    Tw_TileSet_FOR_EACH(board->Players[col].OpenCorners.Keys, tile, 
+    {
+        Tw_TileList_Push(out, tile); 
+    });
+}

--- a/Source/Tilewe/Board.h
+++ b/Source/Tilewe/Board.h
@@ -508,6 +508,21 @@ static inline int Tw_Board_NumMovesForPlayer(const Tw_Board* board, Tw_Color for
 }
 
 /**
+ * Checks if a move is legal given the current board state. 
+ * 
+ * @param board Board
+ * @param move Move
+ * @return Whether the move is legal 
+ */
+static inline bool Tw_Board_IsLegal(const Tw_Board* board, Tw_Move move) 
+{
+    Tw_RotPcCon rpc = Tw_Move_RotPcCon(move); 
+    Tw_Tile target = Tw_Move_ToTile(move); 
+
+    return rpc < Tw_NumRotPcCons && Tw_Tile_InBounds(target) && Tw_RotPcConSet_Has(&board->Players[board->CurTurn].OpenCorners.Sets[target], rpc); 
+}
+
+/**
  * Get number of legal moves for the current player. 
  * 
  * @param board Board

--- a/Source/Tilewe/Move.h
+++ b/Source/Tilewe/Move.h
@@ -10,7 +10,7 @@
  */
 typedef Tw_UInt32 Tw_Move; 
 
-#define Tw_Move_None ((Tw_Move) -1)
+#define Tw_NoMove ((Tw_Move) -1)
 
 /**
  * @param rpc Rotation-piece-contact
@@ -26,15 +26,45 @@ static inline Tw_Move Tw_MakeMoveFromRotPcCon(Tw_RotPcCon rpc, Tw_Tile toTile)
  * Convenience constructor to build move from a piece, rotation, contact, and
  * target tile. 
  * 
+ * The piece, rotation, contact must be a valid combination. 
+ * The target tile must be in bounds. 
+ * 
  * @param pc Piece
  * @param rot Rotation
  * @param con Contact
  * @param toTile Target tile
- * @return 
+ * @return The move 
  */
 static inline Tw_Move Tw_MakeMove(Tw_Pc pc, Tw_Rot rot, Tw_Tile con, Tw_Tile toTile) 
 {
     return Tw_MakeMoveFromRotPcCon(Tw_RotPcInfos[Tw_ToRotPc(pc, rot)].ToRotPcCon[con], toTile); 
+}
+
+/**
+ * Convenience constructor to build move from a piece, rotation, contact, and
+ * target tile. 
+ * 
+ * If any of the parameters would cause the move to be invalid then it returns
+ * `Tw_NoMove`.
+ * 
+ * @param pc Piece
+ * @param rot Rotation
+ * @param con Contact
+ * @param toTile Target tile
+ * @return The move 
+ */
+static inline Tw_Move Tw_MakeMove_Safe(Tw_Pc pc, Tw_Rot rot, Tw_Tile con, Tw_Tile toTile) 
+{
+    if (pc < 0 || pc >= Tw_NumPcs || 
+        rot < 0 || rot >= Tw_NumRots ||
+        !Tw_Tile_InBounds(con) ||
+        !Tw_Tile_InBounds(toTile) ||
+        !Tw_TileSet_Has(&Tw_RotPcInfos[Tw_ToRotPc(pc, rot)].Contacts, con))
+    {
+        return Tw_NoMove; 
+    }
+
+    return Tw_MakeMove(pc, rot, con, toTile); 
 }
 
 /**

--- a/Source/Tilewe/Piece.h
+++ b/Source/Tilewe/Piece.h
@@ -1,6 +1,7 @@
 #pragma once 
 
 #include "Bits.h" 
+#include "StackList.h"
 #include "Tile.h" 
 #include "Types.h"
 
@@ -42,6 +43,8 @@ typedef enum Tw_Pc
 
     Tw_Pc_None = Tw_NumPcs
 } Tw_Pc; 
+
+Tw_DEFINE_STACK_LIST(PcList, Tw_Pc, Tw_NumPcs)
 
 /**
  * Piece string. 


### PR DESCRIPTION
Includes: 

- Getting player pieces
- Getting player corners
- Checking move legality